### PR TITLE
further improve g_ranzal action loop

### DIFF
--- a/adv/g_ranzal.py
+++ b/adv/g_ranzal.py
@@ -8,7 +8,7 @@ def module():
 
 
 class G_Ranzal(Adv):
-    comment = "3FS & first S1 with 1 bar"
+    comment = "3FS & first S1 with 1 gauge & S2 with >=30% gauge"
 
     conf = {}
     conf['slots.a'] = VC() + First_Rate_Hospitality()
@@ -154,7 +154,7 @@ if __name__ == '__main__':
         # from core.timeline import now
         `s1, this.gauges['x'] >=1000 and now()<10
         `s1, this.gauges['x'] >=1000 and this.gauges['fs'] >= 1000
-        `s2, fsc
+        `s2, fsc and this.gauges['fs'] >= 300
         `fs, cancel and seq=3 
         `s3, fsc
         """


### PR DESCRIPTION
Changed to not use S2 until FS gauge is at least 30% full. Performance in the three minute sim increases from 2766 to 2821.