### PR TITLE
improve g_ranzal action loop for 60 second sim

### DIFF
--- a/adv/g_ranzal.py
+++ b/adv/g_ranzal.py
@@ -8,7 +8,6 @@ def module():
 
 
 class G_Ranzal(Adv):
-    comment = "3FS & first S1 with 1 gauge & S2 with >=30% gauge"
 
     conf = {}
     conf['slots.a'] = VC() + First_Rate_Hospitality()
@@ -150,7 +149,22 @@ if __name__ == '__main__':
     #     `s3, fsc
     #     """
 
-    conf['acl'] = """
+    import sys
+    if len(sys.argv) >= 3:
+        sim_duration = int(sys.argv[2])
+    else:
+        sim_duration = 180
+    if sim_duration <= 60:
+        conf['acl'] = """
+        # from core.timeline import now
+        `s1, fsc
+        `s2, fsc
+        `fs, cancel and seq=3 
+        `s3, fsc
+        """
+        module().comment += '3FS & dont hold S1'
+    else:
+        conf['acl'] = """
         # from core.timeline import now
         `s1, this.gauges['x'] >=1000 and now()<10
         `s1, this.gauges['x'] >=1000 and this.gauges['fs'] >= 1000
@@ -158,5 +172,6 @@ if __name__ == '__main__':
         `fs, cancel and seq=3 
         `s3, fsc
         """
+        module().comment += '3FS & first S1 with 1 gauge & S2 with >=30% gauge'
 
     adv_test.test(module(), conf, verbose=0, mass=0)


### PR DESCRIPTION
Use a rotation with less ramp time for 60 seconds sim. Performance improves from 2636 to 2749.